### PR TITLE
PHP 7.4.0 get_magic_quotes_gpc() is deprecated

### DIFF
--- a/openid.php
+++ b/openid.php
@@ -732,7 +732,11 @@ class LightOpenID
             # wants to verify. stripslashes() should solve that problem, but we can't
             # use it when magic_quotes is off.
             $value = $this->data['openid_' . str_replace('.','_',$item)];
-            $params['openid.' . $item] = function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() ? stripslashes($value) : $value;
+            if (version_compare(phpversion(), '7.4.0', '<')) {
+                $params['openid.' . $item] = function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() ? stripslashes($value) : $value;
+            } else {
+                $params['openid.' . $item] = $value;
+            }
 
         }
 


### PR DESCRIPTION
see https://github.com/Mewp/lightopenid/issues/86